### PR TITLE
feat: add extension-provided code snippets

### DIFF
--- a/_extensions/toc-depth/_snippets.json
+++ b/_extensions/toc-depth/_snippets.json
@@ -1,0 +1,7 @@
+{
+	"Hidden from TOC": {
+		"prefix": "toc-depth",
+		"body": "## ${1:Section Title} {toc-depth=0}",
+		"description": "Create a section header hidden from the table of contents"
+	}
+}

--- a/_extensions/toc-depth/_snippets.json
+++ b/_extensions/toc-depth/_snippets.json
@@ -1,6 +1,6 @@
 {
 	"Hidden from TOC": {
-		"prefix": "toc-depth",
+		"prefix": "depth",
 		"body": "## ${1:Section Title} {toc-depth=0}",
 		"description": "Create a section header hidden from the table of contents"
 	}


### PR DESCRIPTION
## Summary

- Add `_snippets.json` file providing VS Code code snippets for Quarto Wizard IntelliSense.
- Related: mcanouil/quarto-wizard#279

## Test plan

- [ ] Verify `_snippets.json` is valid JSON.
- [ ] Install extension in a Quarto project with Quarto Wizard and verify snippets appear in IntelliSense.