### PR TITLE
feat: Add document-level default depth option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: Add `extensions.toc-depth.default` option to set a document-wide default depth applied to headers without an explicit `toc-depth` attribute.
+
 ## 0.4.0 (2026-03-23)
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ This will NOT appear in TOC (depth = 3).
 This section uses the default TOC behaviour.
 ```
 
+### Document-level default depth
+
+You can set a document-wide default depth so you do not have to annotate every header.
+Configure the integer option `extensions.toc-depth.default` in `_quarto.yml`, `_metadata.yml`, or the document front matter.
+
+```yaml
+filters:
+  - toc-depth
+extensions:
+  toc-depth:
+    default: 1
+```
+
+The default is applied to every header that does not carry an explicit `toc-depth` attribute.
+An explicit per-header `toc-depth` attribute always overrides the document default.
+
+```markdown
+# Section A
+
+This section appears in the TOC, but its direct children are hidden (default = 1).
+
+## Subsection A1
+
+This is hidden from the TOC because of the document default.
+
+# Section B {toc-depth=2}
+
+This section overrides the default, so its direct children appear in the TOC.
+
+## Subsection B1
+
+This appears in the TOC because of the explicit override.
+```
+
 ## Example
 
 Here is the source code for a minimal example: [example.qmd](example.qmd).

--- a/_extensions/toc-depth/_schema.yml
+++ b/_extensions/toc-depth/_schema.yml
@@ -1,10 +1,22 @@
 # _schema.yml for "toc-depth" filter extension
-# Describes attributes for IDE tooling and runtime validation.
+# Describes options and attributes for IDE tooling and runtime validation.
+
+# Extension-level metadata options.
+# Configured in _quarto.yml, _metadata.yml, or document front matter:
+#   extensions:
+#     toc-depth:
+#       default: 1
 
 # Attributes accepted by the filter on Header elements.
 # Used in: ## Section Title {toc-depth=1}
 
 $schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  default:
+    type: integer
+    min: 0
+    description: "Document-wide default toc-depth applied to headers without an explicit toc-depth attribute. An explicit per-header toc-depth attribute always overrides this default."
 
 attributes:
   Header:

--- a/_extensions/toc-depth/toc-depth.lua
+++ b/_extensions/toc-depth/toc-depth.lua
@@ -15,6 +15,9 @@ local reference_level = nil
 --- @type number The current toc-depth value being applied
 local current_toc_depth = 1
 
+--- @type number|nil The document-wide default toc-depth applied to headers without an explicit attribute
+local default_toc_depth = nil
+
 
 --- Add a class to the class list if it doesn't already exist
 --- @param classes table List of CSS classes
@@ -33,14 +36,36 @@ local function get_toc_depth_from_attributes(attributes)
   return nil
 end
 
+--- Read the document-wide default toc-depth from metadata
+--- @param meta table Document metadata table
+--- @return table The unchanged document metadata table
+--- @description Reads the integer option extensions.toc-depth.default and stores it
+--- as the fallback toc-depth for headers without an explicit toc-depth attribute
+local function get_toc_depth_meta(meta)
+  if meta['extensions'] and meta['extensions']['toc-depth'] and meta['extensions']['toc-depth']['default'] then
+    default_toc_depth = tonumber(pandoc.utils.stringify(meta['extensions']['toc-depth']['default']))
+  end
+  return meta
+end
+
 --- Process a header element to apply toc-depth filtering
 --- @param elem table Pandoc Header element with properties: level, attributes, classes
 --- @return table|nil The modified header element or nil if no changes needed
 --- @description This function handles two scenarios:
 --- 1. If the header has a toc-depth attribute, it becomes a "parent" and sets the reference
 --- 2. If we're processing children of a parent header, it applies the toc-depth rules
+--- An explicit toc-depth attribute always overrides the document-wide default.
 local function process_header(elem)
   local toc_depth = get_toc_depth_from_attributes(elem.attributes)
+
+  if is_parent and not toc_depth and elem.level <= reference_level then
+    is_parent = false
+    reference_level = nil
+  end
+
+  if not toc_depth and not is_parent then
+    toc_depth = default_toc_depth
+  end
 
   if toc_depth then
     is_parent = true
@@ -54,12 +79,6 @@ local function process_header(elem)
   end
 
   if is_parent then
-    if elem.level <= reference_level then
-      is_parent = false
-      reference_level = nil
-      return elem
-    end
-
     if elem.level > reference_level then
       local relative_depth = elem.level - reference_level
       if relative_depth >= current_toc_depth then
@@ -74,9 +93,11 @@ local function process_header(elem)
 end
 
 --- Pandoc filter configuration
---- @return table Filter configuration with Header walker function
---- @description Returns a Pandoc filter that processes Header elements to apply
---- custom toc-depth behaviour based on the toc-depth attribute
+--- @return table Filter configuration with Meta and Header walker functions
+--- @description Returns a Pandoc filter that reads the document-wide default depth
+--- then processes Header elements to apply custom toc-depth behaviour based on the
+--- toc-depth attribute, falling back to the document default when no attribute is set
 return {
+  { Meta = get_toc_depth_meta },
   { Header = process_header }
 }

--- a/example.qmd
+++ b/example.qmd
@@ -14,6 +14,9 @@ format:
     toc-expand: true
 filters:
   - toc-depth
+extensions:
+  toc-depth:
+    default: 1
 ---
 
 # Installation
@@ -40,17 +43,28 @@ Then control TOC depth for specific sections using the `toc-depth` attribute on 
 The TOC depth is relative to the section where it is defined.
 :::
 
-# Section with Default TOC Behaviour
+You can also set a document-wide default depth so you do not have to annotate every header.
 
-This section uses Quarto's default table of contents behaviour.
+```yaml
+extensions:
+  toc-depth:
+    default: 1
+```
+
+This document sets `extensions.toc-depth.default: 1`.
+An explicit per-header `toc-depth` attribute always overrides this default.
+
+# Section with the Document Default
+
+This section uses the document-wide default of `1`, so it appears in the TOC, but its direct children are hidden.
 
 ## Subsection 1.1
 
-This subsection will appear in the TOC.
+This subsection will NOT appear in the TOC because of the document default (depth = 2).
 
 ### Subsection 1.1.1
 
-This nested subsection will also appear in the TOC.
+This nested subsection will also NOT appear in the TOC because of the document default (depth = 3).
 
 # Section Hidden from TOC {toc-depth=0}
 
@@ -104,6 +118,26 @@ This will NOT appear in the TOC (depth = 3).
 
 This will also not appear in the TOC (depth = 4).
 
+# Section Overriding the Document Default {toc-depth=2}
+
+```markdown
+# Section Overriding the Document Default {toc-depth=2}
+```
+
+This section overrides the document default of `1` with an explicit `toc-depth=2`, so its direct children appear in the TOC.
+
+## Visible Subsection 5.1
+
+This subsection will appear in the TOC because of the explicit override (depth = 2).
+
+### Hidden Subsection 5.1.1
+
+This nested subsection will NOT appear in the TOC (depth = 3).
+
 # Final Section
 
-This section returns to the default TOC behaviour and will display all subsections according to your document settings.
+This section returns to the document-wide default of `1`, so it appears in the TOC, but its direct children are hidden.
+
+## Hidden Subsection 6.1
+
+This subsection will NOT appear in the TOC because of the document default (depth = 2).


### PR DESCRIPTION
Adds an `extensions.toc-depth.default` option that sets a document-wide table of contents depth for headers without an explicit `toc-depth` attribute. An explicit attribute still overrides the default.