### PR TITLE
fix(toc-depth): reset state, validate depth, document cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Reset module-level cascade state in the `Meta` pass so batch renders no longer leak state between documents.
+- fix: Clamp negative `toc-depth` values to `0` and emit a warning instead of silently producing inverted cascade behaviour.
+- fix: Warn on non-numeric `toc-depth` attributes and on non-numeric `extensions.toc-depth.default` values instead of accepting them silently.
+
+### Documentation
+
+- docs: Document the `toc-depth=0` dual effect (`unlisted` and `unnumbered`).
+- docs: Document the cascade-override rule with a worked example where a child re-opens the TOC for its sub-tree.
+- docs: Add a cross-format support statement covering HTML, LaTeX/PDF, DOCX, and Typst.
+- docs: Document input validation (negative and non-numeric values).
+
+### Refactoring
+
+- refactor: Add shared `logging.lua` module and route warnings through `quarto.log.warning` with the `[toc-depth]` prefix.
+
 ## 0.5.0 (2026-05-24)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ quarto add mcanouil/quarto-toc-depth@0.5.0
 This will install the extension under the `_extensions` subdirectory.
 If you're using version control, you will want to check in this directory.
 
+## Format support
+
+The filter applies the Pandoc `unlisted` and `unnumbered` classes to headers, which is the standard mechanism used by Quarto to control TOC inclusion and numbering.
+Supported output formats are those whose TOC honours those classes:
+
+- HTML (including revealjs).
+- LaTeX/PDF.
+- DOCX (numbering only; TOC inclusion depends on the Word template).
+- Typst (via Quarto's Typst writer).
+
+The classes do not affect formats without a generated TOC (e.g. plain markdown, PPTX).
+
 ## Usage
 
 Add the filter to your document's YAML header:
@@ -63,6 +75,43 @@ This will NOT appear in TOC (depth = 3).
 This section uses the default TOC behaviour.
 ```
 
+### `toc-depth=0`: hide the header and its sub-headings
+
+Setting `toc-depth=0` on a header has two effects:
+
+- The header itself is hidden from the TOC (Pandoc `unlisted` class).
+- The header is also marked as `unnumbered`, so it will not receive a section number.
+
+All sub-headings inherit the cascade and are likewise hidden and unnumbered, unless a child overrides the cascade with its own `toc-depth` attribute.
+
+### Cascade override: a child can change the depth for its sub-tree
+
+A child header with an explicit `toc-depth` attribute takes over the cascade for itself and its sub-headings, replacing the depth inherited from its ancestor.
+
+```markdown
+# Parent {toc-depth=1}
+
+`Parent` appears in the TOC, but its direct children are hidden.
+
+## Child A
+
+Hidden, inherited from `Parent`.
+
+## Child B {toc-depth=3}
+
+`Child B` overrides the cascade with a wider depth.
+
+### Grandchild B1
+
+Appears in the TOC because of the override on `Child B`.
+
+#### Great-grandchild B1.1
+
+Appears in the TOC because the override caps the visible depth at `3`.
+```
+
+A child override can also tighten the cascade (e.g. set `toc-depth=0` on a child to hide a single sub-tree under a parent with `toc-depth=2`).
+
 ### Document-level default depth
 
 You can set a document-wide default depth so you do not have to annotate every header.
@@ -96,6 +145,14 @@ This section overrides the default, so its direct children appear in the TOC.
 
 This appears in the TOC because of the explicit override.
 ```
+
+### Input validation
+
+`toc-depth` must be a non-negative integer.
+Negative or non-numeric values are reported as warnings during rendering:
+
+- Negative values are clamped to `0` (header and sub-headings hidden from TOC).
+- Non-numeric values are ignored and the header falls back to the document default or normal Quarto behaviour.
 
 ## Example
 

--- a/_extensions/toc-depth/_modules/logging.lua
+++ b/_extensions/toc-depth/_modules/logging.lua
@@ -1,0 +1,62 @@
+--- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
+--- @module logging
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- LOGGING UTILITIES
+-- ============================================================================
+
+--- Format and log an error message with extension prefix.
+--- Provides standardised error messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The error message to display
+--- @usage M.log_error("external", "Could not open file 'example.md'.")
+function M.log_error(extension_name, message)
+  quarto.log.error('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a warning message with extension prefix.
+--- Provides standardised warning messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The warning message to display
+--- @usage M.log_warning("lua-env", "No variable name provided.")
+function M.log_warning(extension_name, message)
+  quarto.log.warning('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log an output message with extension prefix.
+--- Provides standardised informational messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The informational message to display
+--- @usage M.log_output("lua-env", "Exported metadata to: output.json")
+function M.log_output(extension_name, message)
+  quarto.log.output('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a debug message with extension prefix.
+--- Provides standardised debug messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The debug message to display
+--- @usage M.log_debug("lua-env", "Variable 'x' has value: 42")
+function M.log_debug(extension_name, message)
+  quarto.log.debug('[' .. extension_name .. '] ' .. message)
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/toc-depth/_schema.yml
+++ b/_extensions/toc-depth/_schema.yml
@@ -1,4 +1,4 @@
-# _schema.yml for "toc-depth" filter extension
+# Schema for the toc-depth extension
 # Describes options and attributes for IDE tooling and runtime validation.
 
 # Extension-level metadata options.
@@ -10,17 +10,17 @@
 # Attributes accepted by the filter on Header elements.
 # Used in: ## Section Title {toc-depth=1}
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   default:
     type: integer
-    min: 0
-    description: "Document-wide default toc-depth applied to headers without an explicit toc-depth attribute. An explicit per-header toc-depth attribute always overrides this default."
+    minimum: 0
+    description: "Document-wide default toc-depth applied to headers without an explicit toc-depth attribute, always overridden by an explicit per-header toc-depth attribute."
 
 attributes:
   Header:
     toc-depth:
       type: integer
-      min: 0
-      description: "Maximum depth of sub-headings to include in the table of contents relative to this header. Set to 0 to exclude this header and all its sub-headings from the TOC."
+      minimum: 0
+      description: "Maximum depth of sub-headings to include in the table of contents relative to this header, where 0 excludes this header and all its sub-headings from the TOC."

--- a/_extensions/toc-depth/toc-depth.lua
+++ b/_extensions/toc-depth/toc-depth.lua
@@ -5,6 +5,10 @@
 
 --- Load modules
 local pdoc = require(quarto.utils.resolve_path('_modules/pandoc-helpers.lua'):gsub('%.lua$', ''))
+local logging = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+
+--- Extension name used as a prefix in log messages
+local EXTENSION_NAME = 'toc-depth'
 
 --- @type boolean Flag indicating if we're currently processing children of a header with toc-depth
 local is_parent = false
@@ -19,6 +23,16 @@ local current_toc_depth = 1
 local default_toc_depth = nil
 
 
+--- Reset module-level cascade state.
+--- Quarto can render multiple documents in one process; without an explicit reset
+--- the cascade flags from a previous document would leak into the next render.
+local function reset_state()
+  is_parent = false
+  reference_level = nil
+  current_toc_depth = 1
+  default_toc_depth = nil
+end
+
 --- Add a class to the class list if it doesn't already exist
 --- @param classes table List of CSS classes
 --- @param name string The class name to add
@@ -26,24 +40,69 @@ local function add_class(classes, name)
   pdoc.add_class(classes, name)
 end
 
+--- Validate a toc-depth value, clamping negatives to 0 with a warning.
+--- @param value number|nil The toc-depth value to validate
+--- @param source string Description of where the value came from (for the warning)
+--- @return number|nil The validated value, or nil if value was nil
+local function validate_toc_depth(value, source)
+  if value == nil then
+    return nil
+  end
+  if value < 0 then
+    logging.log_warning(
+      EXTENSION_NAME,
+      string.format(
+        "Negative toc-depth value %d from %s; clamping to 0 (header and sub-headings hidden from TOC).",
+        value,
+        source
+      )
+    )
+    return 0
+  end
+  return value
+end
+
 --- Extract the toc-depth value from element attributes
 --- @param attributes table|nil Element attributes table
 --- @return number|nil The toc-depth value if found and valid, nil otherwise
 local function get_toc_depth_from_attributes(attributes)
   if attributes and attributes['toc-depth'] then
-    return tonumber(attributes['toc-depth'])
+    local raw = tonumber(attributes['toc-depth'])
+    if raw == nil then
+      logging.log_warning(
+        EXTENSION_NAME,
+        string.format(
+          "Non-numeric toc-depth attribute %q; ignoring.",
+          tostring(attributes['toc-depth'])
+        )
+      )
+      return nil
+    end
+    return validate_toc_depth(raw, 'header attribute')
   end
   return nil
 end
 
---- Read the document-wide default toc-depth from metadata
+--- Read the document-wide default toc-depth from metadata and reset per-document state
 --- @param meta table Document metadata table
 --- @return table The unchanged document metadata table
---- @description Reads the integer option extensions.toc-depth.default and stores it
---- as the fallback toc-depth for headers without an explicit toc-depth attribute
+--- @description Resets module-level cascade state so a fresh render does not inherit
+--- state from a previous document in the same Quarto process, then reads the integer
+--- option extensions.toc-depth.default and stores it as the fallback toc-depth for
+--- headers without an explicit toc-depth attribute. Negative values are clamped to 0
+--- with a warning.
 local function get_toc_depth_meta(meta)
+  reset_state()
   if meta['extensions'] and meta['extensions']['toc-depth'] and meta['extensions']['toc-depth']['default'] then
-    default_toc_depth = tonumber(pandoc.utils.stringify(meta['extensions']['toc-depth']['default']))
+    local raw = tonumber(pandoc.utils.stringify(meta['extensions']['toc-depth']['default']))
+    if raw == nil then
+      logging.log_warning(
+        EXTENSION_NAME,
+        'Non-numeric extensions.toc-depth.default; ignoring.'
+      )
+    else
+      default_toc_depth = validate_toc_depth(raw, 'extensions.toc-depth.default')
+    end
   end
   return meta
 end
@@ -55,6 +114,7 @@ end
 --- 1. If the header has a toc-depth attribute, it becomes a "parent" and sets the reference
 --- 2. If we're processing children of a parent header, it applies the toc-depth rules
 --- An explicit toc-depth attribute always overrides the document-wide default.
+--- When toc-depth is 0, the header is hidden from the TOC and unnumbered.
 local function process_header(elem)
   local toc_depth = get_toc_depth_from_attributes(elem.attributes)
 
@@ -94,9 +154,10 @@ end
 
 --- Pandoc filter configuration
 --- @return table Filter configuration with Meta and Header walker functions
---- @description Returns a Pandoc filter that reads the document-wide default depth
---- then processes Header elements to apply custom toc-depth behaviour based on the
---- toc-depth attribute, falling back to the document default when no attribute is set
+--- @description Returns a Pandoc filter that resets per-document state and reads the
+--- document-wide default depth, then processes Header elements to apply custom toc-depth
+--- behaviour based on the toc-depth attribute, falling back to the document default when
+--- no attribute is set.
 return {
   { Meta = get_toc_depth_meta },
   { Header = process_header }

--- a/example.qmd
+++ b/example.qmd
@@ -11,6 +11,7 @@ format:
   html:
     output-file: index
     toc: true
+    toc-depth: 4
     toc-expand: true
 filters:
   - toc-depth
@@ -134,10 +135,43 @@ This subsection will appear in the TOC because of the explicit override (depth =
 
 This nested subsection will NOT appear in the TOC (depth = 3).
 
+# Cascade Override: Child Widens the TOC {toc-depth=1}
+
+```markdown
+# Cascade Override: Child Widens the TOC {toc-depth=1}
+```
+
+This parent limits the TOC to depth `1`, so its direct children would normally be hidden from the TOC.
+A child can override the cascade for its own sub-tree by setting an explicit `toc-depth` attribute.
+
+## Inherited Child 6.1
+
+This subsection inherits the parent's cascade of `toc-depth=1` and is hidden from the TOC.
+
+## Overriding Child 6.2 {toc-depth=3}
+
+```markdown
+## Overriding Child 6.2 {toc-depth=3}
+```
+
+This subsection overrides the parent's cascade with `toc-depth=3`, so it and the next two levels of headings appear in the TOC.
+
+### Visible Grandchild 6.2.1
+
+This nested subsection appears in the TOC because of the override on its parent.
+
+#### Visible Great-grandchild 6.2.1.1
+
+This deeper subsection also appears in the TOC because the override caps the visible depth at `3`.
+
+##### Hidden Great-great-grandchild 6.2.1.1.1
+
+This deeper subsection is hidden because it exceeds the override's depth of `3`.
+
 # Final Section
 
 This section returns to the document-wide default of `1`, so it appears in the TOC, but its direct children are hidden.
 
-## Hidden Subsection 6.1
+## Hidden Subsection 7.1
 
 This subsection will NOT appear in the TOC because of the document default (depth = 2).


### PR DESCRIPTION
Address the `quarto-toc-depth` findings from the May 2026 review.
Batch-render state leakage, silent acceptance of negative depths, and undocumented behaviour around `toc-depth=0` and cascade overrides.

- fix: Reset module-level cascade state (`is_parent`, `reference_level`, `current_toc_depth`, `default_toc_depth`) in the `Meta` pass so batch renders do not leak state between documents.
- fix: Clamp negative `toc-depth` values (both per-header attribute and `extensions.toc-depth.default`) to `0` and emit a `quarto.log.warning` instead of producing inverted-cascade output silently.
- fix: Warn on non-numeric `toc-depth` attributes and on non-numeric `extensions.toc-depth.default` instead of accepting them silently.
- refactor: Add shared `logging.lua` to `_modules/` and route all warnings through `logging.log_warning` with the `[toc-depth]` prefix.
- docs: Document the `toc-depth=0` dual effect (applies `unlisted` and `unnumbered`).
- docs: Document the cascade-override rule with a worked example showing a child widening the TOC depth for its sub-tree.
- docs: Add a cross-format support statement covering HTML, LaTeX/PDF, DOCX, and Typst.
- docs: Document input validation behaviour for negative and non-numeric values.
- test: Extend `example.qmd` with a cascade-override section (parent `toc-depth=1`, overriding child `toc-depth=3`) and raise `toc-depth: 4` in the rendered HTML to demonstrate the override end to end.
